### PR TITLE
Adds a CNAME file to mkdocs root

### DIFF
--- a/site/CNAME
+++ b/site/CNAME
@@ -1,0 +1,1 @@
+honeypot.silverton.io


### PR DESCRIPTION
The gh pages custom domain keeps dropping when deployment automation kicks off. This fixes that.