### PR TITLE
Don't use minio in quickstart - use local schemas

### DIFF
--- a/examples/quickstart/docker-compose.yml
+++ b/examples/quickstart/docker-compose.yml
@@ -47,21 +47,6 @@ services:
     ports:
       - 8081:8080
 
-  minio:
-    container_name: minio
-    image: quay.io/minio/minio
-    command: server /data --console-address ":9001"
-    ports:
-      - 9000:9000
-      - 9001:9001
-    volumes:
-      - ./minio/:/data
-    healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
-      interval: 30s
-      timeout: 20s
-      retries: 3
-
   redpanda-1:
     << : *redpanda
     container_name: redpanda-1

--- a/examples/quickstart/honeypot/quickstart.conf.yml
+++ b/examples/quickstart/honeypot/quickstart.conf.yml
@@ -74,12 +74,8 @@ inputs:
 
 schemaCache:
   backend:
-    type: minio
-    minioEndpoint: minio:9000
-    accessKeyId: minioadmin
-    secretAccessKey: minioadmin
-    bucket: honeypot-schemas
-    path: /
+    type: fs
+    path: /schemas/
   ttlSeconds: 300
   maxSizeBytes: 104857600 # 100mb -> 100 * 1024 * 1024
   purge:
@@ -98,6 +94,9 @@ sinks:
       - redpanda-3:29094 # internally advertised
     invalidTopic: hpt-invalid
     validTopic: hpt-valid
+  - name: secondary
+    type: stdout
+    deliveryRequired: true
 
 squawkBox:
   enabled: true


### PR DESCRIPTION
This PR:
* Scraps `minio` in the quickstart, in favor of local schemas (fewer moving pieces)
* Adds `stdout` sink in the quickstart, so feedback is quick and easy

cc @dehume 